### PR TITLE
Improve the robustness of argument parsing.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           version: '2021.08.06'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: clj-kondo
         run: clj-kondo --lint src
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: lein deps
@@ -56,7 +56,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Lein
         run: lein uberjar
@@ -89,7 +89,7 @@ jobs:
           - linux-x86_64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Make
         run: make
@@ -129,7 +129,7 @@ jobs:
           - apple-darwin-x86_64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download artifact
         uses: actions/download-artifact@v2.0.5
@@ -189,7 +189,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download artifact
         uses: actions/download-artifact@v2.0.5
@@ -263,7 +263,7 @@ jobs:
           bats-version: 1.4.1
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create directory for bats extensions
         if: "!contains(matrix.target, 'windows')"
@@ -403,7 +403,7 @@ jobs:
       release_tag: ${{ steps.tag.outputs.tag }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get tag
         id: tag
@@ -438,7 +438,7 @@ jobs:
           - linux-x86_64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download artifact
         uses: actions/download-artifact@v2.0.5
@@ -490,7 +490,7 @@ jobs:
           - linux-x86_64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download artifact
         uses: actions/download-artifact@v2.0.5
@@ -535,7 +535,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v2
 
@@ -607,7 +607,7 @@ jobs:
           - windows-x86_64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download checksum artifact
         if: contains(matrix.target, 'linux')
@@ -754,7 +754,7 @@ jobs:
           - linux-x86_64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download checksum
         uses: actions/download-artifact@v2.0.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           version: '2021.08.06'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: clj-kondo
         run: clj-kondo --lint src
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: lein deps
@@ -57,7 +57,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Lein
         run: lein uberjar
@@ -96,7 +96,7 @@ jobs:
           - linux-x86_64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Make
         run: make
@@ -128,7 +128,7 @@ jobs:
           - apple-darwin-x86_64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download artifact
         uses: actions/download-artifact@v2.0.5
@@ -180,7 +180,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download artifact
         uses: actions/download-artifact@v2.0.5
@@ -252,7 +252,7 @@ jobs:
           bats-version: 1.4.1
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create directory for bats extensions
         if: "!contains(matrix.target, 'windows')"

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ TAGS
 /*.deb
 /test/xyz/thoren/bats/
 *.DS_Store
+/bibcal.build_artifacts.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV BIN_NAME="bibcal"
 
 # The current versions to build against:
 ENV MUSL_VERSION="1.2.3"
-ENV ZLIB_VERSION="1.2.12"
+ENV ZLIB_VERSION="1.2.13"
 ENV GRAALVM_VERSION="22.1.0"
 
 # Set the shell options:

--- a/test/xyz/thoren/bibcal.bats
+++ b/test/xyz/thoren/bibcal.bats
@@ -285,7 +285,7 @@ load "$(pwd)/test/xyz/thoren/bats/assertion-test-helpers"
     run ./bibcal 2023 08 01
     assert_status 0
     assert_line_matches 0 "14th day of the 5th month"
-    assert_line_matches -1 "2023-08-01 21:30:00"
+    assert_line_matches -1 "Start of next day"
 }
 
 @test "invoking bibcal 2021" {

--- a/test/xyz/thoren/bibcal.bats
+++ b/test/xyz/thoren/bibcal.bats
@@ -285,7 +285,7 @@ load "$(pwd)/test/xyz/thoren/bats/assertion-test-helpers"
     run ./bibcal 2023 08 01
     assert_status 0
     assert_line_matches 0 "14th day of the 5th month"
-    assert_line_equals -1 "2023-08-01 21:30:00"
+    assert_line_matches -1 "2023-08-01 21:30:00"
 }
 
 @test "invoking bibcal 2021" {

--- a/test/xyz/thoren/bibcal.bats
+++ b/test/xyz/thoren/bibcal.bats
@@ -276,6 +276,18 @@ load "$(pwd)/test/xyz/thoren/bats/assertion-test-helpers"
     assert_line_matches 0 DEBUG
 }
 
+# This test should catch the issue with octal numbers described in issue #6
+# https://github.com/johanthoren/bibcal/issues/6
+@test "invoking bibcal 2023 08 01" {
+    if [ ! "$(uname)" = "Linux" ]; then
+        skip "This test only runs on Linux"
+    fi
+    run ./bibcal 2023 08 01
+    assert_status 0
+    assert_line_matches 0 "14th day of the 5th month"
+    assert_line_equals -1 "2023-08-01 21:30:00"
+}
+
 @test "invoking bibcal 2021" {
     if [ ! "$(uname)" = "Linux" ]; then
         skip "This test only runs on Linux"


### PR DESCRIPTION
A java.lang.NumberFormatException was thrown when 08 or 09 were given as arguments. This commit improves on the argument parsing and avoids this error.

This solves #6.